### PR TITLE
fixed ejs compile issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "bootstrap": "^3.3.7",
-    "ejs": "*",
+    "ejs": "2.7.1",
     "express": "3.3.5",
     "jquery": "3.3.1"
   }


### PR DESCRIPTION
Since the package.json file has "*" specified for ejs version, an incompatible version of ejs can be installed and ran, which causes page render issues. The view ejs files do not support ejs 3.* or higher.