### PR TITLE
fixed API endpoint

### DIFF
--- a/public/scripts/functions.js
+++ b/public/scripts/functions.js
@@ -1,7 +1,7 @@
 function submitComment(commentControl) {
     var comments = document.getElementsByName(commentControl)[0].value;
     var subscriptionKey = "TEXT_ANALYTICS_API_KEY";
-    var url = "TEXT_ANALYTICS_ENDPOINT/sentiment";
+    var url = "TEXT_ANALYTICS_ENDPOINT/text/analytics/v2.1/sentiment";
 
     var payload = '{ "documents": [ { "language": "en-US", "id": "1", "text": "' + comments + '" }]}';
 


### PR DESCRIPTION
Changed the default API endpoint to be "text/analytics/v2.1/sentiment" instead of "/sentiment" on the url variable. This fixes 404 errors that would be returned by the Text Analytics API if just "/sentiment" was used.